### PR TITLE
Attempt to make create no_std compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,14 @@ version = "0.1.0"
 authors = ["Bruno Tavares <connect+github@bltavares.com>"]
 edition = "2018"
 
+[features]
+default = ["std"]
+std = ["regex/use_std"]
+alloc = []
+
 [dependencies]
 url = "2.1.0"
-regex = "1.2.1"
+regex = { default-features = false, version = "1.2.1" }
 lazy_static = "1.3.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,23 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
+
 use core::fmt;
+use core::str::FromStr;
 use lazy_static::lazy_static;
 use regex::Regex;
-use std::borrow::Cow;
-use std::str::FromStr;
 use url::Url;
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+mod compat {
+    pub use alloc::borrow::Cow;
+    pub use alloc::string::{String, ToString};
+}
+#[cfg(feature = "std")]
+mod compat {
+    pub use std::borrow::Cow;
+}
+
+use crate::compat::*;
 
 lazy_static! {
     static ref VERSION_REGEX: Regex = Regex::new(


### PR DESCRIPTION
This is an initial attempt to make the crate no_std compatible.

Most of the features of the crate wouln't work, as neither `url` nor
`regex` are no_std compat yet.

It is more likely that `regex` becomes `no_std` compat than `url`, and
if that happens, we could make a new version of the parser without
adding the url attribute on the struct.